### PR TITLE
Rework strict abc

### DIFF
--- a/pymine_net/net/asyncio/server.py
+++ b/pymine_net/net/asyncio/server.py
@@ -1,9 +1,9 @@
 import asyncio
 from typing import Dict, Tuple, Union
+from abc import abstractmethod
 
 from pymine_net.net.asyncio.stream import AsyncTCPStream
 from pymine_net.net.server import AbstractProtocolServer, AbstractProtocolServerClient
-from pymine_net.strict_abc import abstract
 from pymine_net.types.packet import ClientBoundPacket, ServerBoundPacket
 from pymine_net.types.packet_map import PacketMap
 
@@ -48,6 +48,6 @@ class AsyncProtocolServer(AbstractProtocolServer):
 
         await self.new_client_connected(client)
 
-    @abstract
+    @abstractmethod
     async def new_client_connected(self, client: AsyncProtocolServerClient) -> None:
         pass

--- a/pymine_net/net/asyncio/server.py
+++ b/pymine_net/net/asyncio/server.py
@@ -1,6 +1,6 @@
 import asyncio
-from typing import Dict, Tuple, Union
 from abc import abstractmethod
+from typing import Dict, Tuple, Union
 
 from pymine_net.net.asyncio.stream import AsyncTCPStream
 from pymine_net.net.server import AbstractProtocolServer, AbstractProtocolServerClient

--- a/pymine_net/net/client.py
+++ b/pymine_net/net/client.py
@@ -1,9 +1,10 @@
 import zlib
 from typing import Type, Union
+from abc import abstractmethod
 
 from pymine_net.enums import GameState, PacketDirection
 from pymine_net.errors import UnknownPacketIdError
-from pymine_net.strict_abc import StrictABC, abstract
+from pymine_net.strict_abc import StrictABC
 from pymine_net.types.buffer import Buffer
 from pymine_net.types.packet import ClientBoundPacket, ServerBoundPacket
 from pymine_net.types.packet_map import PacketMap
@@ -21,11 +22,11 @@ class AbstractProtocolClient(StrictABC):
         self.state = GameState.HANDSHAKING
         self.compression_threshold = -1
 
-    @abstract
+    @abstractmethod
     def connect(self) -> None:
         pass
 
-    @abstract
+    @abstractmethod
     def close(self) -> None:
         pass
 
@@ -63,10 +64,10 @@ class AbstractProtocolClient(StrictABC):
 
         return packet_class.unpack(buf)
 
-    @abstract
+    @abstractmethod
     def read_packet(self) -> ClientBoundPacket:
         pass
 
-    @abstract
+    @abstractmethod
     def write_packet(self, packet: ServerBoundPacket) -> None:
         pass

--- a/pymine_net/net/client.py
+++ b/pymine_net/net/client.py
@@ -1,6 +1,6 @@
 import zlib
-from typing import Type, Union
 from abc import abstractmethod
+from typing import Type, Union
 
 from pymine_net.enums import GameState, PacketDirection
 from pymine_net.errors import UnknownPacketIdError

--- a/pymine_net/net/server.py
+++ b/pymine_net/net/server.py
@@ -1,6 +1,6 @@
 import zlib
-from typing import Dict, Tuple, Type, Union
 from abc import abstractmethod
+from typing import Dict, Tuple, Type, Union
 
 from pymine_net.enums import GameState, PacketDirection
 from pymine_net.errors import UnknownPacketIdError

--- a/pymine_net/net/server.py
+++ b/pymine_net/net/server.py
@@ -1,10 +1,11 @@
 import zlib
 from typing import Dict, Tuple, Type, Union
+from abc import abstractmethod
 
 from pymine_net.enums import GameState, PacketDirection
 from pymine_net.errors import UnknownPacketIdError
 from pymine_net.net.stream import AbstractTCPStream
-from pymine_net.strict_abc import StrictABC, abstract
+from pymine_net.strict_abc import StrictABC
 from pymine_net.types.buffer import Buffer
 from pymine_net.types.packet import ClientBoundPacket, ServerBoundPacket
 from pymine_net.types.packet_map import PacketMap
@@ -55,11 +56,11 @@ class AbstractProtocolServerClient(StrictABC):
 
         return packet_class.unpack(buf)
 
-    @abstract
+    @abstractmethod
     def read_packet(self) -> ServerBoundPacket:
         pass
 
-    @abstract
+    @abstractmethod
     def write_packet(self, packet: ClientBoundPacket) -> None:
         pass
 
@@ -75,10 +76,10 @@ class AbstractProtocolServer(StrictABC):
 
         self.connected_clients: Dict[Tuple[str, int], AbstractProtocolServerClient] = {}
 
-    @abstract
+    @abstractmethod
     def run(self) -> None:
         pass
 
-    @abstract
+    @abstractmethod
     def close(self) -> None:
         pass

--- a/pymine_net/net/socket/server.py
+++ b/pymine_net/net/socket/server.py
@@ -1,10 +1,10 @@
 import socket
 import threading
 from typing import Dict, List, Tuple, Union
+from abc import abstractmethod
 
 from pymine_net.net.server import AbstractProtocolServer, AbstractProtocolServerClient
 from pymine_net.net.socket.stream import SocketTCPStream
-from pymine_net.strict_abc import abstract
 from pymine_net.types.packet import ClientBoundPacket, ServerBoundPacket
 from pymine_net.types.packet_map import PacketMap
 
@@ -60,6 +60,6 @@ class SocketProtocolServer(AbstractProtocolServer):
         with client.stream.sock:
             self.new_client_connected(client)
 
-    @abstract
+    @abstractmethod
     def new_client_connected(self, client: SocketProtocolServerClient) -> None:
         pass

--- a/pymine_net/net/socket/server.py
+++ b/pymine_net/net/socket/server.py
@@ -1,7 +1,7 @@
 import socket
 import threading
-from typing import Dict, List, Tuple, Union
 from abc import abstractmethod
+from typing import Dict, List, Tuple, Union
 
 from pymine_net.net.server import AbstractProtocolServer, AbstractProtocolServerClient
 from pymine_net.net.socket.stream import SocketTCPStream

--- a/pymine_net/net/stream.py
+++ b/pymine_net/net/stream.py
@@ -1,9 +1,9 @@
-from pymine_net.strict_abc import abstract
+from abc import abstractmethod
 
 
 class AbstractTCPStream:
     """Abstract class for a TCP stream."""
 
-    @abstract
+    @abstractmethod
     def read_varint(self) -> int:
         pass

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -96,6 +96,12 @@ class StrictABCMeta(ABCMeta):
         - If the second (compare) function doesn't have any annotations, check fails (TypeError).
         - If the second (compare) function's signature isn't compatible the expected signature, check fails (TypeError).
         - Otherwise, if the signatures are compatible, the check is passed (returns None).
+
+        NOTE: This check works, but it's not at all reliable, and it's behavior with forward references is very much
+        incomplete and inaccurate, and it will never be accurate, because doing type-enforcing on runtime like this
+        simply isn't something that the python's typing system was designed for, types should be ensured with a proper
+        type-checker, not with runtime checks. This also completely lacks support for subtypes which don't pass issubclass
+        check, such as protocols. This is only here temporarily, until a type-checker is added which will replace this.
         """
         try:
             expected_ann = inspect.get_annotations(expected_f, eval_str=True)

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -16,13 +16,26 @@ if TYPE_CHECKING:
 
 
 
-__all__ = ("StrictABC", "optionalabstractmethod")
+__all__ = ("StrictABC", "optionalabstractmethod", "is_abstract")
 
 
 def optionalabstractmethod(funcobj: Callable) -> Callable:
+    """Marks given function as an optional abstract method.
+
+    This means it's presnce won't be required, but if it will be present, we can
+    run the typing checks provided by the strict ABC.
+
+    NOTE: This will get removed along with the entire type-enforcement system eventually.
+    """
     funcobj.__isabstractmethod__ = True  # Mimics abc.abstractmethod behavior
     funcobj.__isoptionalabstractmethod__ = True
     return funcobj
+
+
+def is_abstract(funcobj: Callable) -> bool:
+    """Checks whether a given function is an abstract function."""
+    return getattr(funcobj, "__isabstractmethod__", False)
+
 
 
 class StrictABCMeta(ABCMeta):

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -58,7 +58,7 @@ class StrictABCMeta(ABCMeta):
 
     @classmethod
     def _check_annotations(mcls, cls: Self, abc_classes: List[Self]) -> None:
-        """Make sure all overidden methods in the class match the original definitions in ABCs.
+        """Make sure all overridden methods in the class match the original definitions in ABCs.
 
         This works by finding every abstract method in the ABC classes (present in the classe's MRO),
         getting their type annotations and comparing them with the annotations in the overridden methods.

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -45,7 +45,7 @@ class StrictABCMeta(ABCMeta):
 
         if definition_check and len(cls.__abstractmethods__) > 0:
             missing_methods = ", ".join(cls.__abstractmethods__)
-            raise TypeError(f"Can't define abstract class Bar with unimplemented abstract methods: {missing_methods}")
+            raise TypeError(f"Can't define class '{name}' with unimplemented abstract methods: {missing_methods}.")
         if typing_check:
             abc_classes = []
             for base_cls in bases:

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -278,11 +278,11 @@ class StrictABCMeta(ABCMeta):
         for opt1, opt2 in compare_checks:
             if opt1 == opt2:
                 return
-        else:
-            raise TypeError(
-                err_msg
-                + f" String forward reference annotations for '{key}' don't match ({exp_val!r} != {cmp_val!r})"
-            )
+
+        raise TypeError(
+            err_msg
+            + f" String forward reference annotations for '{key}' don't match ({exp_val!r} != {cmp_val!r})"
+        )
 
 
 class StrictABC(metaclass=StrictABCMeta):

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -1,124 +1,133 @@
 """
-Contains a "strict" implementation of abc.ABC, as only Python 3.10+ actually enforces abc.ABC.
+Contains a "strict" implementation of abc.ABC, enforcing presnce of all abstract methods on class creation.
 
 - Subclasses of abstract classes must implement all abstract methods/classmethods/staticmethods
 - A method's typehints are also enforced, if abstract method a has a return annotation of MyClass,
     the implemented method must have a return annotation of MyClass or a subclass of MyClass.
 """
+from __future__ import annotations
 
-from typing import Optional, Tuple, Type
+import inspect
+from abc import ABCMeta
+from typing import Tuple, List, Callable, Type, TYPE_CHECKING
 
-__all__ = ("abstract", "StrictABC")
-
-
-class AbstractObjData:
-    __slots__ = ("optional", "annotations")
-
-    def __init__(self, optional: bool = False, annotations: dict = None):
-        self.optional = optional
-        self.annotations = annotations
+if TYPE_CHECKING:
+    from typing_extensions import Self
 
 
-def abstract(obj):
-    obj.__abstract__ = AbstractObjData(annotations=getattr(obj, "__annotations__", None))
-    return obj
+
+__all__ = ("StrictABC", )
 
 
-def optionalabstract(obj):
-    obj.__abstract__ = AbstractObjData(
-        optional=True, annotations=getattr(obj, "__annotations__", None)
-    )
-    return obj
+class StrictABCMeta(ABCMeta):
+    """Strict extension of abc.ABCMeta, enforcing abstract methods on definitions and typing checks.
 
+    Regular abc.ABCMeta only enforces abstract methods to be present on class initialization,
+    however, this often isn't enough, because we usually want to get runtime errors immediately,
+    whenever a class  would be defined without implementing all of the abstract methods. With
+    behavior like this, we can ensure that we encounter a runtime failure before this behavior ever
+    gets a chance of affecting things, this is especially important for static and class methods which
+    don't need initialization to be called.
 
-def is_abstract(obj) -> bool:
-    return hasattr(obj, "__abstract__")
+    This class also introduces typing checks, which require the overridden methods to follow the
+    type-hints specified in the initial abstract methods. This prevents bad unexpected behavior,
+    and it enforces clean type checkable code."""
 
-
-def check_annotations(a: dict, b: dict) -> bool:
-    for k, v in a.items():
-        if k not in b:
-            return False
-
-        if type(v) is str:
-            return type(b[k]) is str and v == b[k]
-
-        try:
-            if not issubclass(b[k], v):
-                return False
-        except TypeError:
-            if b[k] is not v:
-                return False
-
-    return True
-
-
-class UnimplementedAbstractError(Exception):
-    def __init__(self, cls_name: str, obj_name: str):
-        super().__init__(f"Class {cls_name} didn't implement abstract {obj_name}.")
-
-
-class MismatchedOverridenAbstractError(Exception):
-    def __init__(
-        self, cls_name: str, obj_name: str, abstract_annotations: dict, obj_annotations: dict
+    def __new__(
+        mcls,
+        name: str,
+        bases: Tuple[Type[object], ...],
+        dct: dict[str, object],
+        definition_check: bool = True,
+        typing_check: bool = True,
     ):
-        super().__init__(
-            f"Overriden abstract {obj_name} of {cls_name} has mismatched annotations: {obj_name}({self.fmt_annos(abstract_annotations)}) != {obj_name}({self.fmt_annos(obj_annotations)})."
-        )
+        cls = super().__new__(mcls, name, bases, dct)
+
+        if definition_check and len(cls.__abstractmethods__) > 0:
+            missing_methods = ", ".join(cls.__abstractmethods__)
+            raise TypeError(f"Can't define abstract class Bar with unimplemented abstract methods: {missing_methods}")
+        if typing_check:
+            abc_classes = []
+            for base_cls in bases:
+                if isinstance(base_cls, mcls) and base_cls is not mcls:
+                    abc_classes.append(base_cls)
+
+            mcls._check_annotations(cls, abc_classes)
+
+        return cls
+
+    @classmethod
+    def _check_annotations(mcls, cls: Self, abc_classes: List[Self]) -> None:
+        """Make sure all overidden methods in the class match the original definitions in ABCs.
+
+        This works by finding every abstract method in the ABC classes (present in the classe's MRO),
+        getting their type annotations and comparing them with the annotations in the overridden methods.
+
+        If an abstract method definition is found, but overridden implementation in the class isn't present,
+        this method will be skipped."""
+        # Get all of the defined abstract methods in the ABCs
+        abc_methods = []
+        for abc_cls in abc_classes:
+            for abc_method_name in abc_cls.__abstractmethods__:
+                abc_method = getattr(abc_cls, abc_method_name)
+                if not callable(abc_method):
+                    raise TypeError(f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable.")
+                abc_methods.append((abc_method_name, abc_method))
+
+        # Get matching overridden methods in the class, to the collected abstract methods
+        _MISSING_SENTINEL = object()
+        for abc_method_name, abc_method in abc_methods:
+            defined_method = getattr(cls, abc_method_name, _MISSING_SENTINEL)
+
+            if defined_method is _MISSING_SENTINEL:
+                continue  # Skip unoverridden abstract methods
+
+            if not callable(defined_method):
+                raise TypeError(f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable.")
+
+            # Compare the annotations
+            mcls._compare_annotations(abc_method, defined_method, abc_method_name)
 
     @staticmethod
-    def fmt_annos(dct: dict) -> str:
-        return ",".join(f"{k}:{getattr(v, '__name__', str(v))}" for k, v in dct.items())
+    def _compare_annotations(expected_f: Callable, compare_f: Callable, method_name: str) -> None:
+        """Compare annotations between two given functions.
 
+        - If the first (expected) function doesn't have any annotations, this check is skipped.
+        - If the second (compare) function doesn't have any annotations, check fails (TypeError).
+        - If the second (compare) function's signature isn't compatible the expected signature, check fails (TypeError).
+        - Otherwise, if the signatures are compatible, the check is passed (returns None).
+        """
+        expected_ann = inspect.get_annotations(expected_f, eval_str=True)
+        compare_ann = inspect.get_annotations(compare_f, eval_str=True)
+        err_msg = f"Mismatched annotations in '{method_name}'."
 
-class StrictABCMeta(type):
-    def __new__(cls, name: str, bases: Tuple[Type[object]], dct: dict):
-        self = super().__new__(cls, name, bases, dct)
+        if len(expected_ann) == 0:  # Nothing to compare
+            return
 
-        # iterate through base classes
-        for base in bases:
-            # iterate through objects
-            for obj_name in dir(base):
-                obj = getattr(base, obj_name)
+        if len(compare_ann) == 0:
+            raise TypeError(err_msg + f" Compare method has no annotations, but some were expected ({expected_ann}).")
 
-                abstract_data: Optional[AbstractObjData] = getattr(obj, "__abstract__", None)
+        for key, exp_val in expected_ann.items():
+            if key not in compare_ann:
+                raise TypeError(err_msg + f" Annotation for '{key}' not present, should be {exp_val}.")
 
-                self_obj = getattr(self, obj_name, None)
+            cmp_val = compare_ann[key]
 
-                # check if it's an abstract object
-                if abstract_data is not None:
-                    # check to see if this class implements that abstract object
-                    if hasattr(self_obj, "__abstract__") and not abstract_data.optional:
-                        raise UnimplementedAbstractError(self.__name__, obj.__name__)
-
-                    if type(self_obj) is not type(obj) and not abstract_data.optional:
-                        raise UnimplementedAbstractError(self.__name__, obj.__name__)
-
-                    # check annotations if there are any
-                    if abstract_data.annotations is not None:
-                        self_obj_annotations = getattr(self_obj, "__annotations__", None)
-
-                        if self_obj_annotations is None and abstract_data.annotations is not None:
-                            raise MismatchedOverridenAbstractError(
-                                self.__name__,
-                                obj.__name__,
-                                abstract_data.annotations,
-                                self_obj_annotations,
-                            )
-
-                        if not check_annotations(abstract_data.annotations, self_obj_annotations):
-                            raise MismatchedOverridenAbstractError(
-                                self.__name__,
-                                obj.__name__,
-                                abstract_data.annotations,
-                                self_obj_annotations,
-                            )
-
-        return self
+            try:
+                if not issubclass(cmp_val, exp_val):
+                    raise TypeError(err_msg + f" Annotation for '{key}' isn't compatible, should be {exp_val}, got {cmp_val}.")
+            except TypeError:
+                # This can happen when cmp_val isn't a class, for example with it set to `None`
+                # Do a literal 'is' comparison here when that happens
+                if cmp_val is not exp_val:
+                    raise TypeError(err_msg + f" Annotation for '{key} isn't compatible, should be {exp_val}, got {cmp_val}.")
 
 
 class StrictABC(metaclass=StrictABCMeta):
-    pass
+    """Strict implementation of abc.ABC, including definition time checks and typing checks.
+
+    For more info, check StrictABCMeta's doocstring."""
+    __slots__ = ()
 
 
 # Example:

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -1,9 +1,11 @@
 """
 Contains a "strict" implementation of abc.ABC, enforcing presnce of all abstract methods on class creation.
 
-- Subclasses of abstract classes must implement all abstract methods/classmethods/staticmethods
-- A method's typehints are also enforced, if abstract method a has a return annotation of MyClass,
-    the implemented method must have a return annotation of MyClass or a subclass of MyClass.
+- Subclasses of StrictABC must implement all abstract methods/classmethods/staticmethods.
+- A method's typehitns are also enforced, however this is only temporary and should be replaced
+    with a type checker. This is currently here just to prevent some accidental misstyping since
+    there's no type-checker yet, however this runtime enforcement isn't perfect and can't fully
+    replace a type-chcker.
 """
 from __future__ import annotations
 

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -200,9 +200,8 @@ class StrictABCMeta(ABCMeta):
                 status, msg = mcls._compare_forward_reference_annotations(exp_val, cmp_val, key)
                 if status is True:
                     return
-                else:
-                    msg = cast(str, msg)
-                    raise TypeError(err_msg + " " + msg)
+                msg = cast(str, msg)
+                raise TypeError(err_msg + " " + msg)
 
             try:
                 if not issubclass(cmp_val, exp_val):

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -197,11 +197,11 @@ class StrictABCMeta(ABCMeta):
             # we can at least check if the string they hold is the same. This isn't ideal,
             # and can cause issues, and incorrect failures, but it's the best we can do.
             if isinstance(cmp_val, str) or isinstance(exp_val, str):
-                status, msg = mcls._compare_forward_reference_annotations(exp_val, cmp_val, key)
+                status, msg = mcls._compare_forward_reference_annotations(exp_val, cmp_val)
                 if status is True:
                     return
                 msg = cast(str, msg)
-                raise TypeError(err_msg + " " + msg)
+                raise TypeError(err_msg + f" Annotation for '{key}' isn't compatible, " + msg)
 
             try:
                 if not issubclass(cmp_val, exp_val):
@@ -221,21 +221,21 @@ class StrictABCMeta(ABCMeta):
     @overload
     @staticmethod
     def _compare_forward_reference_annotations(
-        exp_val: str, cmp_val: object, key: str
+        exp_val: str, cmp_val: object
     ) -> Tuple[bool, Optional[str]]:
         ...
 
     @overload
     @staticmethod
     def _compare_forward_reference_annotations(
-        exp_val: object, cmp_val: str, key: str
+        exp_val: object, cmp_val: str
     ) -> Tuple[bool, Optional[str]]:
         ...
 
     @overload
     @staticmethod
     def _compare_forward_reference_annotations(
-        exp_val: str, cmp_val: str, key: str
+        exp_val: str, cmp_val: str
     ) -> Tuple[bool, Optional[str]]:
         ...
 
@@ -243,7 +243,6 @@ class StrictABCMeta(ABCMeta):
     def _compare_forward_reference_annotations(
         exp_val: Union[str, object],
         cmp_val: Union[str, object],
-        key: str,
     ) -> Tuple[bool, Optional[str]]:
         """This compares 2 annotations, out of which at least one is a string.
 
@@ -282,8 +281,8 @@ class StrictABCMeta(ABCMeta):
             if len(compare_checks) == 0:
                 return (
                     False,
-                    f"Can't compare annotations for '{key}', unable to convert a real object to a string"
-                    f" for comparison against a string forward reference annotation. {real!r} ?= {fwd!r}",
+                    "unable to convert a real object to a string for comparison against a"
+                    f" string forward reference annotation. {real!r} ?= {fwd!r}",
                 )
 
         # Also try to get the "unqualified names" and if comparing those succeed,
@@ -307,7 +306,7 @@ class StrictABCMeta(ABCMeta):
 
         return (
             False,
-            f" String forward reference annotations for '{key}' don't match ({exp_val!r} != {cmp_val!r})",
+            f" string forward references don't match ({exp_val!r} != {cmp_val!r})",
         )
 
 

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -32,7 +32,7 @@ def optionalabstractmethod(funcobj: Callable) -> Callable:
 
 def is_abstract(funcobj: Callable) -> bool:
     """Checks whether a given function is an abstract function."""
-    return getattr(funcobj, "__isabstractmethod__", False)
+    return getattr(funcobj, "__isabstractmethod__", False) or getattr(funcobj, "__isoptionalabstractmethod__", False)
 
 
 class StrictABCMeta(ABCMeta):

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Callable, List, Tuple, Type, overload, Union, cast
+from typing import TYPE_CHECKING, Callable, List, Tuple, Type, Union, cast, overload
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -32,7 +32,9 @@ def optionalabstractmethod(funcobj: Callable) -> Callable:
 
 def is_abstract(funcobj: Callable) -> bool:
     """Checks whether a given function is an abstract function."""
-    return getattr(funcobj, "__isabstractmethod__", False) or getattr(funcobj, "__isoptionalabstractmethod__", False)
+    return getattr(funcobj, "__isabstractmethod__", False) or getattr(
+        funcobj, "__isoptionalabstractmethod__", False
+    )
 
 
 class StrictABCMeta(ABCMeta):
@@ -62,10 +64,16 @@ class StrictABCMeta(ABCMeta):
         # Find all abstract methods and optional abstract methods which are still present and weren't overridden
         # excluding those defined in this class directly, since if a class defines new abstract method in it,
         # we obviously don't expect it to be implemented in that class.
-        ab_methods = {method_name for method_name in cls.__abstractmethods__ if method_name not in cls.__dict__}
+        ab_methods = {
+            method_name
+            for method_name in cls.__abstractmethods__
+            if method_name not in cls.__dict__
+        }
         optional_ab_methods = {
-            method_name for method_name in dir(cls)
-            if getattr(getattr(cls, method_name), "__isoptionalabstractmethod__", False) and method_name not in cls.__dict__
+            method_name
+            for method_name in dir(cls)
+            if getattr(getattr(cls, method_name), "__isoptionalabstractmethod__", False)
+            and method_name not in cls.__dict__
         }
 
         if definition_check and len(ab_methods) > 0:
@@ -117,7 +125,6 @@ class StrictABCMeta(ABCMeta):
                         )
                     ab_methods.append((obj_name, obj_value))
 
-
         # Get matching overridden methods in the class, to the collected abstract methods
         _MISSING_SENTINEL = object()
         for ab_method_name, ab_method in ab_methods:
@@ -135,7 +142,12 @@ class StrictABCMeta(ABCMeta):
             mcls._compare_annotations(ab_method, defined_method, ab_method_name)
 
     @classmethod
-    def _compare_annotations(mcls, expected_f: Callable, compare_f: Callable, method_name: str) -> None:
+    def _compare_annotations(
+        mcls,
+        expected_f: Callable,
+        compare_f: Callable,
+        method_name: str,
+    ) -> None:
         """Compare annotations between two given functions.
 
         - If the first (expected) function doesn't have any annotations, this check is skipped.
@@ -202,14 +214,17 @@ class StrictABCMeta(ABCMeta):
 
     @overload
     @staticmethod
-    def _compare_forward_reference_annotations(exp_val: str, cmp_val: object, err_msg: str, key: str):
+    def _compare_forward_reference_annotations(
+        exp_val: str, cmp_val: object, err_msg: str, key: str
+    ):
         ...
 
     @overload
     @staticmethod
-    def _compare_forward_reference_annotations(exp_val: object, cmp_val: str, err_msg: str, key: str):
+    def _compare_forward_reference_annotations(
+        exp_val: object, cmp_val: str, err_msg: str, key: str
+    ):
         ...
-
 
     @overload
     @staticmethod

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -9,11 +9,10 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta
-from typing import Tuple, List, Callable, Type, TYPE_CHECKING
+from typing import TYPE_CHECKING, Callable, List, Tuple, Type
 
 if TYPE_CHECKING:
     from typing_extensions import Self
-
 
 
 __all__ = ("StrictABC", "optionalabstractmethod", "is_abstract")
@@ -35,7 +34,6 @@ def optionalabstractmethod(funcobj: Callable) -> Callable:
 def is_abstract(funcobj: Callable) -> bool:
     """Checks whether a given function is an abstract function."""
     return getattr(funcobj, "__isabstractmethod__", False)
-
 
 
 class StrictABCMeta(ABCMeta):
@@ -70,7 +68,9 @@ class StrictABCMeta(ABCMeta):
                     missing_methods.append(ab_method_name)
 
             missing_methods_str = ", ".join(cls.__abstractmethods__)
-            raise TypeError(f"Can't define class '{name}' with unimplemented abstract methods: {missing_methods_str}.")
+            raise TypeError(
+                f"Can't define class '{name}' with unimplemented abstract methods: {missing_methods_str}."
+            )
         if typing_check:
             abc_classes = []
             for base_cls in bases:
@@ -96,7 +96,9 @@ class StrictABCMeta(ABCMeta):
             for abc_method_name in abc_cls.__abstractmethods__:
                 abc_method = getattr(abc_cls, abc_method_name)
                 if not callable(abc_method):
-                    raise TypeError(f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable.")
+                    raise TypeError(
+                        f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable."
+                    )
                 abc_methods.append((abc_method_name, abc_method))
 
         # Get matching overridden methods in the class, to the collected abstract methods
@@ -108,7 +110,9 @@ class StrictABCMeta(ABCMeta):
                 continue  # Skip unoverridden abstract methods
 
             if not callable(defined_method):
-                raise TypeError(f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable.")
+                raise TypeError(
+                    f"Expected '{abc_method_name}' to be an abstractmethod, but it isn't callable."
+                )
 
             # Compare the annotations
             mcls._compare_annotations(abc_method, defined_method, abc_method_name)
@@ -143,11 +147,16 @@ class StrictABCMeta(ABCMeta):
             return
 
         if len(compare_ann) == 0:
-            raise TypeError(err_msg + f" Compare method has no annotations, but some were expected ({expected_ann}).")
+            raise TypeError(
+                err_msg
+                + f" Compare method has no annotations, but some were expected ({expected_ann})."
+            )
 
         for key, exp_val in expected_ann.items():
             if key not in compare_ann:
-                raise TypeError(err_msg + f" Annotation for '{key}' not present, should be {exp_val}.")
+                raise TypeError(
+                    err_msg + f" Annotation for '{key}' not present, should be {exp_val}."
+                )
 
             cmp_val = compare_ann[key]
 
@@ -159,11 +168,15 @@ class StrictABCMeta(ABCMeta):
                     cmp_val = getattr(cmp_val, "__name__", None)
                     if cmp_val is None:
                         raise TypeError(
-                            err_msg + f" Can't compare annotations for '{key}', unable to evaluate the string forward reference"
+                            err_msg
+                            + f" Can't compare annotations for '{key}', unable to evaluate the string forward reference"
                             f", and '__name__' of the compare function isn't available."
                         )
                 if exp_val != cmp_val:
-                    raise TypeError(err_msg + f" Forward reference annotations for '{key}' don't match ({exp_val!r} != {cmp_val!r})")
+                    raise TypeError(
+                        err_msg
+                        + f" Forward reference annotations for '{key}' don't match ({exp_val!r} != {cmp_val!r})"
+                    )
 
                 # If we know the strings in the forward reference annotations are the same,
                 # we can assume that they mean the same thing and mark the type check as passing,
@@ -173,12 +186,18 @@ class StrictABCMeta(ABCMeta):
 
             try:
                 if not issubclass(cmp_val, exp_val):
-                    raise TypeError(err_msg + f" Annotation for '{key}' isn't compatible, should be {exp_val}, got {cmp_val}.")
+                    raise TypeError(
+                        err_msg
+                        + f" Annotation for '{key}' isn't compatible, should be {exp_val}, got {cmp_val}."
+                    )
             except TypeError:
                 # This can happen when cmp_val isn't a class, for example with it set to `None`
                 # Do a literal 'is' comparison here when that happens
                 if cmp_val is not exp_val:
-                    raise TypeError(err_msg + f" Annotation for '{key} isn't compatible, should be {exp_val}, got {cmp_val}.")
+                    raise TypeError(
+                        err_msg
+                        + f" Annotation for '{key} isn't compatible, should be {exp_val}, got {cmp_val}."
+                    )
 
 
 class StrictABC(metaclass=StrictABCMeta):
@@ -208,4 +227,5 @@ class StrictABC(metaclass=StrictABCMeta):
     >>> # No issues here
 
     For more info, check StrictABCMeta's doocstring."""
+
     __slots__ = ()

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 import inspect
 from abc import ABCMeta
-from typing import TYPE_CHECKING, Callable, List, Tuple, Type, Union, cast, overload, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional, Tuple, Type, Union, cast, overload
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -153,29 +153,28 @@ class StrictABCMeta(ABCMeta):
 class StrictABC(metaclass=StrictABCMeta):
     """Strict implementation of abc.ABC, including definition time checks and typing checks.
 
+    Example:
+    >>> class AbstractTest(StrinctABC):
+    ...     @abstractmethod
+    ...     def foo(self, x: int) -> int:
+    ...         pass
+    >>> class Test(AbstractTest):
+    ...     def foo(self, x: int) -> int
+    ...         return 2 + x
+    >>> class NotTest(AbstractTest):
+    ...     def bar(self, x: int) -> int:
+    ...         return 5 + x
+    TypeError: Can't define class 'NotTest' with unimplemented abstract methods: foo.
+    >>> class NotTest2(AbstractTest):
+    ...     def foo(self, x: str) -> str:
+    ...         return "hi " + x
+    TypeError: Mismatched annotations in 'foo'. Annotation for 'x' isn't compatible, should be int, got str.
+    >>> class ExtendedAbstractTest(StrictABC, definition_check=False):
+    ...     @classmethod
+    ...     @abstractmethod
+    ...     def bar(cls, x: str) -> str:
+    ...         pass
+    >>> # No issues here
+
     For more info, check StrictABCMeta's doocstring."""
     __slots__ = ()
-
-
-# Example:
-# class AbstractTest(StrictABC):
-#     def __init__(self, something):
-#         self.something = something
-
-# class AbstractTest2(AbstractTest):
-#     @abstract
-#     def my_abstract_method(self, a: str):
-#         print("in abstract method")
-
-#     @classmethod
-#     @abstract
-#     def my_abstract_classmethod(self, a: str):
-#         print("in abstract classmethod")
-
-# class Test(AbstractTest2):
-#     def my_abstract_method(self, a: str):
-#         print("in method")
-
-#     @classmethod
-#     def my_abstract_classmethod(self, a: str):
-#         print("in classmethod")

--- a/pymine_net/strict_abc.py
+++ b/pymine_net/strict_abc.py
@@ -213,7 +213,7 @@ class StrictABCMeta(ABCMeta):
                 if cmp_val is not exp_val:
                     raise TypeError(
                         err_msg
-                        + f" Annotation for '{key} isn't compatible, should be {exp_val}, got {cmp_val}."
+                        + f" Annotation for '{key}' isn't compatible, should be {exp_val}, got {cmp_val}."
                     )
 
 

--- a/pymine_net/types/block_palette.py
+++ b/pymine_net/types/block_palette.py
@@ -1,17 +1,19 @@
-from strict_abc import StrictABC, abstract
+from abc import abstractmethod
+
+from strict_abc import StrictABC
 
 __all__ = ("BlockPalette",)
 
 
 class BlockPalette(StrictABC):
-    @abstract
+    @abstractmethod
     def get_bits_per_block(self) -> int:
         pass
 
-    @abstract
+    @abstractmethod
     def encode(self, block: str, props: dict = None) -> int:
         pass
 
-    @abstract
+    @abstractmethod
     def decode(self, state: int) -> dict:
         pass

--- a/pymine_net/types/packet.py
+++ b/pymine_net/types/packet.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from pymine_net.strict_abc import StrictABC, abstract, optionalabstract
+from abc import abstractmethod
+
+from pymine_net.strict_abc import StrictABC, optionalabstractmethod
 from pymine_net.types.buffer import Buffer
 
 __all__ = ("Packet", "ServerBoundPacket", "ClientBoundPacket")
@@ -24,12 +26,12 @@ class ServerBoundPacket(Packet):
     :ivar id:
     """
 
-    @optionalabstract
+    @optionalabstractmethod
     def pack(self) -> Buffer:
         raise NotImplementedError
 
-    @abstract
     @classmethod
+    @abstractmethod
     def unpack(cls, buf: Buffer) -> ServerBoundPacket:
         pass
 
@@ -41,11 +43,11 @@ class ClientBoundPacket(Packet):
     :ivar id:
     """
 
-    @abstract
+    @abstractmethod
     def pack(self) -> Buffer:
         pass
 
     @classmethod
-    @optionalabstract
+    @optionalabstractmethod
     def unpack(cls, buf: Buffer) -> ClientBoundPacket:
         raise NotImplementedError

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -135,4 +135,3 @@ def test_forward_annotation_comparison():
         StrictABC._compare_forward_reference_annotations(Bar, "Foo", Mock(), Mock())
     with pytest.raises(TypeError):
         StrictABC._compare_forward_reference_annotations("Foo", Bar, Mock(), Mock())
-

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -34,7 +34,7 @@ class Helpers:
 
 
 def test_abc_creation():
-    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_func})
+    test_cls = type("TestAbstract", (StrictABC,), {"foo": Helpers.helper_func})
 
     assert hasattr(test_cls, "foo")  # Make sure the class was properly made with the func
     foo = getattr(test_cls, "foo")
@@ -49,58 +49,60 @@ def test_abc_creation():
 
 
 def test_abc_definition_enforcement():
-    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_ab_func })
+    test_cls = type("TestAbstract", (StrictABC,), {"foo": Helpers.helper_ab_func})
 
     # Fail for class without overridden definition
     with pytest.raises(TypeError):
-        type("Test", (test_cls, ), {})
+        type("Test", (test_cls,), {})
 
     # Succeed for class with overridden definition
-    type("Test", (test_cls, ), {"foo": Helpers.helper_func})
+    type("Test", (test_cls,), {"foo": Helpers.helper_func})
 
     # Succeed for class without overridden definition, with ignored definition check
-    type("ExtendedTestAbstract", (test_cls, ), {}, definition_check=False)
+    type("ExtendedTestAbstract", (test_cls,), {}, definition_check=False)
 
 
 def test_abc_no_optional_definition_enforcement():
-    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_optional_ab_func})
+    test_cls = type("TestAbstract", (StrictABC,), {"foo": Helpers.helper_optional_ab_func})
 
     # Should succeed, even without providing a definition of the optional abstract function
-    type("Test", (test_cls, ), {})
+    type("Test", (test_cls,), {})
 
     # Should succeed with overridden optional abstract function with valid function
-    type("Test", (test_cls, ), {"foo": Helpers.helper_func})
+    type("Test", (test_cls,), {"foo": Helpers.helper_func})
 
 
 def test_abc_typing_enforcement():
-    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_annotated_ab_func})
+    test_cls = type("TestAbstract", (StrictABC,), {"foo": Helpers.helper_annotated_ab_func})
 
     # Fail for class without matching type annotated overridden method
     with pytest.raises(TypeError):
-        type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func})
+        type("Test", (test_cls,), {"foo": Helpers.helper_unannoteated_func})
 
     # Succeed for class with matching type annotated overridden method
-    type("Test", (test_cls, ), {"foo": Helpers.helper_annotated_func})
+    type("Test", (test_cls,), {"foo": Helpers.helper_annotated_func})
 
     # Succeed for class wtthout matching type annotated overridden method, but without type-check enabled
-    type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func}, typing_check=False)
+    type("Test", (test_cls,), {"foo": Helpers.helper_unannoteated_func}, typing_check=False)
 
     # Succeed for unoverridden method (without definition check)
-    type("Test", (test_cls, ), {}, definition_check=False)
+    type("Test", (test_cls,), {}, definition_check=False)
 
 
 def test_abc_optional_typing_enforcement():
-    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_annotated_optional_ab_func})
+    test_cls = type(
+        "TestAbstract", (StrictABC,), {"foo": Helpers.helper_annotated_optional_ab_func}
+    )
 
     # Succeed for unoverridden method (without definition check)
-    type("Test", (test_cls, ), {}, definition_check=False)
+    type("Test", (test_cls,), {}, definition_check=False)
 
     # Succeed for class with matching type annotated overridden method
-    type("Test", (test_cls, ), {"foo": Helpers.helper_annotated_func})
+    type("Test", (test_cls,), {"foo": Helpers.helper_annotated_func})
 
     # Fail for class without matching type annotated overridden maethod
     with pytest.raises(TypeError):
-        type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func})
+        type("Test", (test_cls,), {"foo": Helpers.helper_unannoteated_func})
 
 
 def test_is_abstract():

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -34,18 +34,21 @@ class Helpers:
 
 
 def test_abc_creation():
-    test_cls = type("TestAbstract", (StrictABC,), {
-        "func": Helpers.helper_func,
-        "ab_func": Helpers.helper_ab_func,
-        "optional_ab_func": Helpers.helper_optional_ab_func,
-    })
+    test_cls = type(
+        "TestAbstract",
+        (StrictABC,),
+        {
+            "func": Helpers.helper_func,
+            "ab_func": Helpers.helper_ab_func,
+            "optional_ab_func": Helpers.helper_optional_ab_func,
+        },
+    )
 
     cases = [
         ("func", {"optional_ab": False, "ab": False}),
         ("ab_func", {"optional_ab": False, "ab": True}),
         ("optional_ab_func", {"optional_ab": True, "ab": False}),
     ]
-
 
     for method_name, params in cases:
         # Make sure the class was properly made with the function

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -135,7 +135,7 @@ def test_is_abstract():
 
 
 def test_forward_annotation_comparison():
-    compare = lambda x, y: StrictABC._compare_forward_reference_annotations(x, y, Mock())[0]
+    compare = lambda x, y: StrictABC._compare_forward_reference_annotations(x, y)[0]
 
     # We should succeed for exactly same forward reference strings
     assert compare("Foo", "Foo") is True

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -135,25 +135,24 @@ def test_is_abstract():
 
 
 def test_forward_annotation_comparison():
+    compare = lambda x, y: StrictABC._compare_forward_reference_annotations(x, y, Mock())[0]
+
     # We should succeed for exactly same forward reference strings
-    StrictABC._compare_forward_reference_annotations("Foo", "Foo", Mock(), Mock())
+    assert compare("Foo", "Foo") is True
 
     # We should also succeed for unqualified comparison for reference strings
-    StrictABC._compare_forward_reference_annotations("py_mine.xyz.Foo", "Foo", Mock(), Mock())
-    StrictABC._compare_forward_reference_annotations("Foo", "py_mine.zyx.Foo", Mock(), Mock())
+    assert compare("py_mine.xyz.Foo", "Foo") is True
+    assert compare("Foo", "py_mine.zyx.Foo") is True
 
     # We should fail if the strings are completely different
-    with pytest.raises(TypeError):
-        StrictABC._compare_forward_reference_annotations("Foo", "Bar", Mock(), Mock())
+    assert compare("Foo", "Bar") is False
 
     Foo = type("Foo", (), {})
     # We should succeed for comparing string "Foo" and real Foo named class
-    StrictABC._compare_forward_reference_annotations(Foo, "Foo", Mock(), Mock())
-    StrictABC._compare_forward_reference_annotations("Foo", Foo, Mock(), Mock())
+    assert compare(Foo, "Foo") is True
+    assert compare("Foo", Foo) is True
 
     Bar = type("Bar", (), {})
     # We should fail for comparing string "Foo" and real Bar named class
-    with pytest.raises(TypeError):
-        StrictABC._compare_forward_reference_annotations(Bar, "Foo", Mock(), Mock())
-    with pytest.raises(TypeError):
-        StrictABC._compare_forward_reference_annotations("Foo", Bar, Mock(), Mock())
+    assert compare(Bar, "Foo") is False
+    assert compare("Foo", Bar) is False

--- a/tests/test_strict_abc.py
+++ b/tests/test_strict_abc.py
@@ -1,0 +1,138 @@
+from abc import abstractmethod
+from unittest.mock import Mock
+
+import pytest
+
+from pymine_net.strict_abc import StrictABC, is_abstract, optionalabstractmethod
+
+
+class Helpers:
+    @abstractmethod
+    def helper_ab_func(self, x):
+        ...
+
+    @optionalabstractmethod
+    def helper_optional_ab_func(self, x):
+        ...
+
+    def helper_func(self, x):
+        return x
+
+    @abstractmethod
+    def helper_annotated_ab_func(self, x: int, y: int) -> int:
+        ...
+
+    @optionalabstractmethod
+    def helper_annotated_optional_ab_func(self, x: int, y: int) -> int:
+        ...
+
+    def helper_annotated_func(self, x: int, y: int) -> int:
+        return x + y
+
+    def helper_unannoteated_func(self, x, y):
+        return x + y
+
+
+def test_abc_creation():
+    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_func})
+
+    assert hasattr(test_cls, "foo")  # Make sure the class was properly made with the func
+    foo = getattr(test_cls, "foo")
+    assert callable(foo)  # Make sure there's no decorator failure
+    # Make sure the function isn't an abstract method/optional abstract method
+    assert not getattr(foo, "__isabstractmethod__", False)
+    assert not getattr(foo, "__isoptionalabstractmethod__", False)
+    # There shouldn't be any abstract methods defined
+    assert hasattr(test_cls, "__abstractmethods__")
+    abstract_methods = getattr(test_cls, "__abstractmethods__")
+    assert len(abstract_methods) == 0
+
+
+def test_abc_definition_enforcement():
+    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_ab_func })
+
+    # Fail for class without overridden definition
+    with pytest.raises(TypeError):
+        type("Test", (test_cls, ), {})
+
+    # Succeed for class with overridden definition
+    type("Test", (test_cls, ), {"foo": Helpers.helper_func})
+
+    # Succeed for class without overridden definition, with ignored definition check
+    type("ExtendedTestAbstract", (test_cls, ), {}, definition_check=False)
+
+
+def test_abc_no_optional_definition_enforcement():
+    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_optional_ab_func})
+
+    # Should succeed, even without providing a definition of the optional abstract function
+    type("Test", (test_cls, ), {})
+
+    # Should succeed with overridden optional abstract function with valid function
+    type("Test", (test_cls, ), {"foo": Helpers.helper_func})
+
+
+def test_abc_typing_enforcement():
+    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_annotated_ab_func})
+
+    # Fail for class without matching type annotated overridden method
+    with pytest.raises(TypeError):
+        type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func})
+
+    # Succeed for class with matching type annotated overridden method
+    type("Test", (test_cls, ), {"foo": Helpers.helper_annotated_func})
+
+    # Succeed for class wtthout matching type annotated overridden method, but without type-check enabled
+    type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func}, typing_check=False)
+
+    # Succeed for unoverridden method (without definition check)
+    type("Test", (test_cls, ), {}, definition_check=False)
+
+
+def test_abc_optional_typing_enforcement():
+    test_cls = type("TestAbstract", (StrictABC, ), {"foo": Helpers.helper_annotated_optional_ab_func})
+
+    # Succeed for unoverridden method (without definition check)
+    type("Test", (test_cls, ), {}, definition_check=False)
+
+    # Succeed for class with matching type annotated overridden method
+    type("Test", (test_cls, ), {"foo": Helpers.helper_annotated_func})
+
+    # Fail for class without matching type annotated overridden maethod
+    with pytest.raises(TypeError):
+        type("Test", (test_cls, ), {"foo": Helpers.helper_unannoteated_func})
+
+
+def test_is_abstract():
+    # is_abstract check should obviously pass for an abstract method
+    assert is_abstract(Helpers.helper_ab_func) is True
+    # is_abstract check should also pass for optional abstract methods
+    assert is_abstract(Helpers.helper_optional_ab_func) is True
+    # is_abstract check should not pass for a regular method
+    assert is_abstract(Helpers.helper_func) is False
+
+
+def test_forward_annotation_comparison():
+    # We should succeed for exactly same forward reference strings
+    StrictABC._compare_forward_reference_annotations("Foo", "Foo", Mock(), Mock())
+
+    # We should also succeed for unqualified comparison for reference strings
+    StrictABC._compare_forward_reference_annotations("py_mine.xyz.Foo", "Foo", Mock(), Mock())
+    StrictABC._compare_forward_reference_annotations("Foo", "py_mine.zyx.Foo", Mock(), Mock())
+
+    # We should fail if the strings are completely different
+    with pytest.raises(TypeError):
+        StrictABC._compare_forward_reference_annotations("Foo", "Bar", Mock(), Mock())
+
+    Foo = type("Foo", (), {})
+    # We should succeed for comparing string "Foo" and real Foo named class
+    StrictABC._compare_forward_reference_annotations(Foo, "Foo", Mock(), Mock())
+    StrictABC._compare_forward_reference_annotations("Foo", Foo, Mock(), Mock())
+
+    Bar = type("Bar", (), {})
+    # We should fail for comparing string "Foo" and real Bar named class
+    with pytest.raises(TypeError):
+        StrictABC._compare_forward_reference_annotations(Bar, "Foo", Mock(), Mock())
+    with pytest.raises(TypeError):
+        StrictABC._compare_forward_reference_annotations("Foo", Bar, Mock(), Mock())
+


### PR DESCRIPTION
This is a complete rewrite of the strict ABC. Rather than writing everything from scratch like in the original implementation, this relies on subclassing an already well implemented and well known `abc.ABCMeta` and extending it's functionalities to our needs.

Note that while this does include the runtime type-enforcing functionality, this feature is fundamentally flawed and needs to be removed in favor of a type-checker eventually.